### PR TITLE
[Feature] #8 - 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// ouath2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/TripleS/VidiLang/domain/test/controller/SwaggerTestController.java
+++ b/src/main/java/TripleS/VidiLang/domain/test/controller/SwaggerTestController.java
@@ -12,9 +12,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class SwaggerTestController {
 
     @Operation(summary = "test API", description = "test API")
-    @GetMapping("string")
+    @GetMapping("/string")
     public String returnStr(){
         return "Hello World";
+    }
+
+    @GetMapping("/test")
+    public String test(){
+        return "test";
     }
 
 }

--- a/src/main/java/TripleS/VidiLang/global/config/RedisConfig.java
+++ b/src/main/java/TripleS/VidiLang/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package TripleS.VidiLang.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+public class RedisConfig {
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
+++ b/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package TripleS.VidiLang.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+		corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+		corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE","PATCH", "HEAD", "OPTIONS"));
+		corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+		corsConfiguration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", corsConfiguration);
+
+		return source;
+	}
+
+
+}

--- a/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
+++ b/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
@@ -14,12 +14,15 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import TripleS.VidiLang.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
 @EnableWebSecurity
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+	private final CustomOAuth2UserService customOAuth2UserService;
+
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration corsConfiguration = new CorsConfiguration();
@@ -40,6 +43,12 @@ public class SecurityConfig {
 		http.authorizeHttpRequests(auth -> auth
 			.requestMatchers("/", "/login", "/join", "/sign-up").permitAll()
 			.anyRequest().authenticated()
+		);
+
+		http.oauth2Login(customConfigurer -> customConfigurer
+			// .successHandler(oAuth2LoginSuccessHandler)
+			// .failureHandler(oAuth2LoginFailureHandler)
+			.userInfoEndpoint(endpointConfig -> endpointConfig.userService(customOAuth2UserService))
 		);
 
 		http.formLogin(FormLoginConfigurer::disable);

--- a/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
+++ b/src/main/java/TripleS/VidiLang/global/config/SecurityConfig.java
@@ -4,7 +4,12 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -29,6 +34,26 @@ public class SecurityConfig {
 
 		return source;
 	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests(auth -> auth
+			.requestMatchers("/", "/login", "/join", "/sign-up").permitAll()
+			.anyRequest().authenticated()
+		);
+
+		http.formLogin(FormLoginConfigurer::disable);
+		http.csrf(AbstractHttpConfigurer::disable);
+
+		return http.build();
+	}
+
+	@Bean
+	public BCryptPasswordEncoder bCryptPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+
 
 
 }

--- a/src/main/java/TripleS/VidiLang/global/exception/SuccessCode.java
+++ b/src/main/java/TripleS/VidiLang/global/exception/SuccessCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
     // 200 OK
     LOGIN_USER_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다"),
+    SIGNUP_USER_SUCCESS(HttpStatus.OK, "회원가입에 성공했습니다"),
     GET_POST_SUCCESS(HttpStatus.OK, "게시글 조회가 완료되었습니다."),
     UPDATE_POST_SUCCESS(HttpStatus.OK, "게시글 수정이 완료되었습니다."),
     SMS_CERT_MESSAGE_SUCCESS(HttpStatus.OK, "메세지 전송이 완료되었습니다."),

--- a/src/main/java/TripleS/VidiLang/jwt/JwtFilter.java
+++ b/src/main/java/TripleS/VidiLang/jwt/JwtFilter.java
@@ -1,0 +1,58 @@
+package TripleS.VidiLang.jwt;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import TripleS.VidiLang.member.entity.SocialType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	private static final List<String> NO_CHECK_URLS = List.of("/login", "/sign-up", "/health-check", "/", "/test"); // filter 요청 필요없는 url
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		String requestURI = request.getRequestURI();
+
+		// 요청 URL이 인증 제외 리스트에 포함되어 있으면 필터를 건너뛰기
+		if (NO_CHECK_URLS.contains(requestURI)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		Optional<String> accessToken = jwtTokenProvider.extractAccessToken(request);
+		Optional<String> refreshToken = jwtTokenProvider.extractRefreshToken(request);
+
+
+		// ✅ AccessToken이 유효하면 인증 진행
+		if (accessToken.isPresent() && jwtTokenProvider.isTokenValid(accessToken.get())) {
+			Authentication auth = jwtTokenProvider.getAuthentication(accessToken.get());
+			SecurityContextHolder.getContext().setAuthentication(auth);
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// ✅ AccessToken이 만료되었지만 RefreshToken이 유효하면 AccessToken 재발급
+
+
+		// ❌ 둘 다 없거나 유효하지 않다면 401 Unauthorized 응답
+		throw new CustomException(ErrorCode.UNAUTHORIZED_EXCEPTION, "유효한 인증 토큰이 없습니다.");
+
+	}
+
+}

--- a/src/main/java/TripleS/VidiLang/jwt/JwtTokenProvider.java
+++ b/src/main/java/TripleS/VidiLang/jwt/JwtTokenProvider.java
@@ -1,0 +1,132 @@
+package TripleS.VidiLang.jwt;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.entity.SocialType;
+import TripleS.VidiLang.member.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	private final MemberRepository memberRepository;
+
+	@Value("${spring.jwt.secret_key}")
+	private String secretKey;
+
+	@Value("${spring.jwt.access.expiration}")
+	private int accessExpiration;
+
+	@Value("${spring.jwt.refresh.expiration}")
+	private int refreshExpiration;
+
+	// Access 토큰 생성
+	public String createAccessToken(String email, SocialType socialType) {
+		Claims claims = Jwts.claims().setSubject(email);
+		claims.put("socialType", socialType.name());
+
+		Date now = new Date();
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + accessExpiration))
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+	}
+
+	// Refresh 토큰 생성 & redis에 저장
+	public String createRefreshToken(String email) {
+		Date now = new Date();
+		String refreshToken = Jwts.builder()
+			.setSubject(email)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + refreshExpiration))
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+
+		redisTemplate.opsForValue().set(email, refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
+		return refreshToken;
+	}
+
+	// 토큰에서 이메일과 socialType을 가져와서 Authentication 객체 생성
+	public Authentication getAuthentication(String token) {
+		Claims claims = Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token)
+			.getBody();
+		String email = claims.getSubject();
+		String socialTypeStr = claims.get("socialType", String.class);
+		SocialType socialType = (socialTypeStr != null) ? SocialType.valueOf(socialTypeStr) : SocialType.LOCAL;
+
+		// 사용자 조회
+		Member member = memberRepository.findByEmailAndSocialType(email, socialType)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_EXCEPTION, "해당 유저가 존재하지 않습니다."));
+
+		// 소셜 로그인 사용자는 비밀번호가 없을 수 있으므로 임시 비밀번호 설정
+		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+		String password = (member.getPassword() != null) ? member.getPassword() : passwordEncoder.encode("defaultPassword");
+
+		UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+			.username(member.getEmail())
+			.password(password)
+			.roles("USER")
+			.build();
+
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+
+	// 토큰 검증 (유효하지 않은 경우 예외 발생)
+	public boolean isTokenValid(String token) {
+		if (token == null || token.isEmpty()) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION, "요청에 유효한 토큰이 없습니다. 인증이 필요합니다.");
+		}
+
+		try {
+			Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+			return true; // 검증 성공
+		} catch (ExpiredJwtException e) {
+			throw new CustomException(ErrorCode.EXPIRED_TOKEN_EXCEPTION, "JWT 토큰이 만료되었습니다.");
+		} catch (JwtException e) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN_EXCEPTION, "유효하지 않은 JWT 토큰입니다.");
+		}
+	}
+
+	// Refresh Token 추출 (Bearer 제거)
+	public Optional<String> extractRefreshToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader("Refresh-Token"))
+			.filter(token -> token.startsWith("Bearer "))
+			.map(token -> token.substring(7));
+	}
+
+	// Access Token 추출 (Bearer 제거)
+	public Optional<String> extractAccessToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader("Authorization"))
+			.filter(token -> token.startsWith("Bearer "))
+			.map(token -> token.substring(7));
+	}
+
+
+
+
+}

--- a/src/main/java/TripleS/VidiLang/login/controller/LoginController.java
+++ b/src/main/java/TripleS/VidiLang/login/controller/LoginController.java
@@ -1,0 +1,26 @@
+package TripleS.VidiLang.login.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import TripleS.VidiLang.global.common.dto.ApiResponseTemplate;
+import TripleS.VidiLang.global.exception.SuccessCode;
+import TripleS.VidiLang.login.dto.SignUpRequest;
+import TripleS.VidiLang.login.service.LoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class LoginController {
+	private final LoginService loginService;
+
+	@PostMapping("/sign-up")
+	public ResponseEntity<ApiResponseTemplate<String>> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+		loginService.signUp(signUpRequest);
+		return ApiResponseTemplate.success(SuccessCode.SIGNUP_USER_SUCCESS, "회원가입이 성공적으로 완료되었습니다.");
+
+	}
+}

--- a/src/main/java/TripleS/VidiLang/login/dto/LoginRequest.java
+++ b/src/main/java/TripleS/VidiLang/login/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package TripleS.VidiLang.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoginRequest {
+	@NotBlank(message = "email을 입력하세요.")
+	private String loginId;
+
+	@NotBlank(message = "비밀번호를 입력하세요.")
+	private String password;
+}

--- a/src/main/java/TripleS/VidiLang/login/dto/SignUpRequest.java
+++ b/src/main/java/TripleS/VidiLang/login/dto/SignUpRequest.java
@@ -1,0 +1,19 @@
+package TripleS.VidiLang.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignUpRequest {
+	@NotBlank(message = "email을 입력하세요.")
+	private String email;
+
+	@NotBlank(message = "비밀번호를 입력하세요.")
+	private String password;
+
+	@NotBlank(message = "닉네임을 입력하세요.")
+	private String nickName;
+}

--- a/src/main/java/TripleS/VidiLang/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/TripleS/VidiLang/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package TripleS.VidiLang.login.filter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+	private static final String DEFAULT_LOGIN_REQUEST_URL = "/login"; // "/login"으로 오는 요청을 처리
+	private static final String HTTP_METHOD = "POST"; // 로그인 HTTP 메소드는 POST
+	private static final String CONTENT_TYPE = "application/json"; // JSON 타입의 데이터로 오는 로그인 요청만 처리
+	private static final String USERNAME_KEY = "email"; // 회원 로그인 시 이메일 요청 JSON Key : "email"
+	private static final String PASSWORD_KEY = "password"; // 회원 로그인 시 비밀번호 요청 JSon Key : "password"
+	private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
+		new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD); // "/login" + POST로 온 요청에 매칭된다.
+
+	private final ObjectMapper objectMapper;
+
+	public CustomJsonUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper) {
+		super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER); // 위에서 설정한 "login" + POST로 온 요청을 처리하기 위해 설정
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
+		AuthenticationException,
+		IOException {
+		if(request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)  ) {
+			throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
+		}
+
+		String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+
+		Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+
+		String email = usernamePasswordMap.get(USERNAME_KEY);
+		String password = usernamePasswordMap.get(PASSWORD_KEY);
+
+		UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);//principal 과 credentials 전달
+
+		return this.getAuthenticationManager().authenticate(authRequest);
+	}
+}

--- a/src/main/java/TripleS/VidiLang/login/handler/LoginFailureHandler.java
+++ b/src/main/java/TripleS/VidiLang/login/handler/LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package TripleS.VidiLang.login.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("text/plain;charset=UTF-8");
+		response.getWriter().write("로그인 실패! 이메일이나 비밀번호를 확인해주세요.");
+	}
+}
+
+

--- a/src/main/java/TripleS/VidiLang/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/TripleS/VidiLang/login/handler/LoginSuccessHandler.java
@@ -1,0 +1,40 @@
+package TripleS.VidiLang.login.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import TripleS.VidiLang.jwt.JwtTokenProvider;
+import TripleS.VidiLang.member.entity.SocialType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+
+		String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
+		SocialType socialType = SocialType.LOCAL;// 인증 정보에서 Username(email) 추출
+
+		String accessToken = jwtTokenProvider.createAccessToken(email, socialType); // AccessToken 발급
+		String refreshToken = jwtTokenProvider.createRefreshToken(email); // RefreshToken 발급
+
+		// 응답 헤더에 토큰 추가
+		response.setHeader("Authorization", "Bearer " + accessToken);
+		response.setHeader("Refresh-Token", refreshToken);
+
+	}
+
+	private String extractUsername(Authentication authentication) {
+		UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+		return userDetails.getUsername();
+	}
+}

--- a/src/main/java/TripleS/VidiLang/login/service/LoginService.java
+++ b/src/main/java/TripleS/VidiLang/login/service/LoginService.java
@@ -1,0 +1,46 @@
+package TripleS.VidiLang.login.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import TripleS.VidiLang.login.dto.SignUpRequest;
+import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.entity.SocialType;
+import TripleS.VidiLang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LoginService {
+	private final MemberRepository memberRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	@Transactional
+	public void signUp(SignUpRequest signUpRequest) {
+		// ✅ 이미 존재하는 이메일 예외 처리
+		if (memberRepository.findByEmail(signUpRequest.getEmail()).isPresent()) {
+			throw new CustomException(ErrorCode.ALREADY_EXIST_SUBJECT_EXCEPTION, "이미 존재하는 이메일입니다.");
+		}
+
+		// ✅ 이미 존재하는 닉네임 예외 처리
+		if (memberRepository.findByNickName(signUpRequest.getNickName()).isPresent()) {
+			throw new CustomException(ErrorCode.ALREADY_EXIST_SUBJECT_EXCEPTION, "이미 존재하는 닉네임입니다.");
+		}
+
+		// ✅ 회원 생성 및 저장
+		Member member = Member.builder()
+			.email(signUpRequest.getEmail())
+			.nickName(signUpRequest.getNickName())
+			.password(signUpRequest.getPassword())
+			.socialType(SocialType.LOCAL)
+			.build();
+
+		member.updatePassword(passwordEncoder.encode(signUpRequest.getPassword()));
+
+		memberRepository.save(member);
+	}
+}

--- a/src/main/java/TripleS/VidiLang/login/service/UserDetailsServiceImpl.java
+++ b/src/main/java/TripleS/VidiLang/login/service/UserDetailsServiceImpl.java
@@ -1,0 +1,30 @@
+package TripleS.VidiLang.login.service;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmail(username)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_EXCEPTION, "해당 이메일이 존재하지 않습니다."));
+
+		return User.builder()
+			.username(member.getEmail())
+			.password(member.getPassword())
+			.build();
+	}
+}

--- a/src/main/java/TripleS/VidiLang/member/entity/Member.java
+++ b/src/main/java/TripleS/VidiLang/member/entity/Member.java
@@ -31,7 +31,6 @@ public class Member extends BaseTimeEntity {
     @Column(name = "MEMBER_EMAIL", unique = true, nullable = false)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false)
@@ -39,6 +38,8 @@ public class Member extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String profileUrl;
+
+    private String socialId; // 로그인한 소셜 타입의 식별자 값
 
     @Enumerated(EnumType.STRING)
     private SocialType socialType;

--- a/src/main/java/TripleS/VidiLang/member/entity/Member.java
+++ b/src/main/java/TripleS/VidiLang/member/entity/Member.java
@@ -36,7 +36,6 @@ public class Member {
     @Column(nullable = false)
     private String nickName;
 
-    @Column(nullable = false)
     private String ImageUrl;
 
     private String socialId; // 로그인한 소셜 타입의 식별자 값
@@ -55,5 +54,9 @@ public class Member {
         this.ImageUrl = imageUrl;
         this.socialId = socialId;
         this.socialType = socialType;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 }

--- a/src/main/java/TripleS/VidiLang/member/entity/Member.java
+++ b/src/main/java/TripleS/VidiLang/member/entity/Member.java
@@ -37,7 +37,7 @@ public class Member extends BaseTimeEntity {
     private String nickName;
 
     @Column(nullable = false)
-    private String profileUrl;
+    private String ImageUrl;
 
     private String socialId; // 로그인한 소셜 타입의 식별자 값
 
@@ -48,11 +48,12 @@ public class Member extends BaseTimeEntity {
     private List<Folder> folders;
 
     @Builder
-    public Member(String email, String password, String nickName, String profileUrl, SocialType socialType) {
+    public Member(String email, String password, String nickName, String imageUrl, String socialId, SocialType socialType) {
         this.email = email;
         this.password = password;
         this.nickName = nickName;
-        this.profileUrl = profileUrl;
+        this.ImageUrl = imageUrl;
+        this.socialId = socialId;
         this.socialType = socialType;
     }
 }

--- a/src/main/java/TripleS/VidiLang/member/entity/Member.java
+++ b/src/main/java/TripleS/VidiLang/member/entity/Member.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
-public class Member extends BaseTimeEntity {
+public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
+++ b/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
@@ -1,9 +1,19 @@
 package TripleS.VidiLang.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.entity.SocialType;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findByNickname(String nickname);
+
+	Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+	Optional<Member> findByEmailAndSocialType(String email, SocialType socialType);
 
 }

--- a/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
+++ b/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package TripleS.VidiLang.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import TripleS.VidiLang.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
+++ b/src/main/java/TripleS/VidiLang/member/repository/MemberRepository.java
@@ -10,7 +10,7 @@ import TripleS.VidiLang.member.entity.SocialType;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 
-	Optional<Member> findByNickname(String nickname);
+	Optional<Member> findByNickName(String nickName);
 
 	Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 

--- a/src/main/java/TripleS/VidiLang/oauth2/OAuthAttributes.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/OAuthAttributes.java
@@ -1,0 +1,59 @@
+package TripleS.VidiLang.oauth2;
+
+import java.util.Map;
+
+import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.entity.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+	private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+	private OAuth2UserInfo oauth2UserInfo; // 소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+	@Builder
+	private OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+		this.nameAttributeKey = nameAttributeKey;
+		this.oauth2UserInfo = oauth2UserInfo;
+	}
+
+
+	public static OAuthAttributes of(SocialType socialType,
+		String userNameAttributeName, Map<String, Object> attributes) {
+		if (socialType == SocialType.KAKAO) {
+			return ofKakao(userNameAttributeName, attributes);
+		}
+		return ofGoogle(userNameAttributeName, attributes);
+	}
+
+	private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+		return OAuthAttributes.builder()
+			.nameAttributeKey(userNameAttributeName)
+			.oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+			.build();
+	}
+
+	public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+		return OAuthAttributes.builder()
+			.nameAttributeKey(userNameAttributeName)
+			.oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+			.build();
+	}
+
+	/*
+	 * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+	 * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+	 * email에는 UUID로 중복 없는 랜덤 값 생성
+	 * role은 GUEST로 설정
+	 */
+	public Member toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+		return Member.builder()
+			.socialType(socialType)
+			.socialId(oauth2UserInfo.getId())
+			.email(oauth2UserInfo.getEmail())
+			.nickname(oauth2UserInfo.getNickname())
+			.imageUrl(oauth2UserInfo.getImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/OAuthAttributes.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/OAuthAttributes.java
@@ -4,6 +4,9 @@ import java.util.Map;
 
 import TripleS.VidiLang.member.entity.Member;
 import TripleS.VidiLang.member.entity.SocialType;
+import TripleS.VidiLang.oauth2.userInfo.GoogleOAuth2UserInfo;
+import TripleS.VidiLang.oauth2.userInfo.KakaoOAuth2UserInfo;
+import TripleS.VidiLang.oauth2.userInfo.OAuth2UserInfo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -41,18 +44,12 @@ public class OAuthAttributes {
 			.build();
 	}
 
-	/*
-	 * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
-	 * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
-	 * email에는 UUID로 중복 없는 랜덤 값 생성
-	 * role은 GUEST로 설정
-	 */
 	public Member toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
 		return Member.builder()
 			.socialType(socialType)
 			.socialId(oauth2UserInfo.getId())
 			.email(oauth2UserInfo.getEmail())
-			.nickname(oauth2UserInfo.getNickname())
+			.nickName(oauth2UserInfo.getNickname())
 			.imageUrl(oauth2UserInfo.getImageUrl())
 			.build();
 	}

--- a/src/main/java/TripleS/VidiLang/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,20 @@
+package TripleS.VidiLang.oauth2.handler;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) {
+
+		throw new CustomException(ErrorCode.AUTHENTICATION_FAILED_EXCEPTION, "소셜 로그인에 실패하였습니다.");
+	}
+
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,83 @@
+package TripleS.VidiLang.oauth2.handler;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import TripleS.VidiLang.global.exception.ErrorCode;
+import TripleS.VidiLang.global.exception.model.CustomException;
+import TripleS.VidiLang.jwt.JwtTokenProvider;
+import TripleS.VidiLang.member.entity.SocialType;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+		throws IOException {
+		// 이메일과 SocialType 가져오기
+		String email = extractEmail(authentication);
+		SocialType socialType = extractSocialType(authentication);
+
+		// 액세스 토큰 & 리프레시 토큰 발급
+		String accessToken = jwtTokenProvider.createAccessToken(email, socialType);
+		String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+		// 로그 출력
+		log.info("✅ Access Token: {}", accessToken);
+		log.info("✅ Refresh Token: {}", refreshToken);
+		log.info("✅ SocialType: {}", socialType);
+
+		// 로그인 성공 후 단순히 "/"로 리다이렉트
+		response.sendRedirect("/test");
+	}
+
+	private String extractEmail(Authentication authentication) {
+		DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+		// email 찾기 (Google, Naver 등)
+		String email = (String) oAuth2User.getAttributes().get("email");
+
+		// Kakao의 경우 kakao_account 내부에 email이 있음
+		if (email == null) {
+			Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes().get("kakao_account");
+			if (kakaoAccount != null) {
+				email = (String) kakaoAccount.get("email");
+			}
+		}
+
+		// 이메일이 여전히 null이면 예외 발생
+		if (email == null) {
+			throw new CustomException(ErrorCode.VALIDATION_REQUEST_FAIL_USERINFO_EXCEPTION, "소셜 로그인 사용자의 이메일을 찾을 수 없습니다.");
+		}
+
+		return email;
+	}
+
+
+	private SocialType extractSocialType(Authentication authentication) {
+		if (authentication instanceof OAuth2AuthenticationToken) {
+			OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+			String provider = oauthToken.getAuthorizedClientRegistrationId(); // OAuth2 제공자 ID 가져오기
+
+			if ("kakao".equalsIgnoreCase(provider)) return SocialType.KAKAO;
+			if ("google".equalsIgnoreCase(provider)) return SocialType.GOOGLE;
+		}
+
+		return SocialType.LOCAL; // 기본값 (예외적인 경우)
+	}
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,80 @@
+package TripleS.VidiLang.oauth2.service;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import TripleS.VidiLang.member.entity.Member;
+import TripleS.VidiLang.member.entity.SocialType;
+import TripleS.VidiLang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final MemberRepository memberRepository;
+	private static final String KAKAO = "kakao";
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+		// DefaultOAuth2UserService 객체를 생성하여 OAuth2User 정보를 가져옴
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+		// OAuth2 제공자의 이름 (예: kakao, naver, google)
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		SocialType socialType = getSocialType(registrationId);
+
+		// UserInfo의 Json 값
+		String userNameAttributeName = userRequest.getClientRegistration()
+			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+
+		// socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+		OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+
+		// 소셜 로그인 유저를 가져오거나 저장
+		Member createdMember = getMember(extractAttributes, socialType);
+
+		// DefaultOAuth2User 반환
+		return new DefaultOAuth2User(
+			Collections.emptySet(),
+			attributes,
+			userNameAttributeName
+		);
+	}
+
+	private SocialType getSocialType(String registrationId) {
+		if (KAKAO.equals(registrationId)) {
+			return SocialType.KAKAO;
+		}
+		return SocialType.GOOGLE;
+	}
+
+	private Member getMember(OAuthAttributes attributes, SocialType socialType) {
+		// 이미 존재하는 유저를 조회
+		Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType, attributes.getOauth2UserInfo().getId()).orElse(null);
+
+		// 유저가 없으면 저장
+		if (findMember == null) {
+			return saveMember(attributes, socialType);
+		}
+		return findMember;
+	}
+
+	private Member saveMember(OAuthAttributes attributes, SocialType socialType) {
+		Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+		return memberRepository.save(createdMember);
+	}
+
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/service/CustomOAuth2UserService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import TripleS.VidiLang.member.entity.Member;
 import TripleS.VidiLang.member.entity.SocialType;
 import TripleS.VidiLang.member.repository.MemberRepository;
+import TripleS.VidiLang.oauth2.OAuthAttributes;
 import lombok.RequiredArgsConstructor;
 
 

--- a/src/main/java/TripleS/VidiLang/oauth2/userInfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/userInfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package TripleS.VidiLang.oauth2.userInfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+	public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getId() {
+		return (String) attributes.get("sub");
+	}
+
+	@Override
+	public String getEmail() {
+		return (String) attributes.get("email");
+	}
+
+	@Override
+	public String getNickname() {
+		return (String) attributes.get("name");
+	}
+
+	@Override
+	public String getImageUrl() {
+		return (String) attributes.get("picture");
+	}
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/userInfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,59 @@
+package TripleS.VidiLang.oauth2.userInfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+	public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+		super(attributes);
+	}
+
+	@Override
+	public String getId() {
+		return String.valueOf(attributes.get("id"));
+	}
+
+	@Override
+	public String getEmail() {
+		Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+		if (account == null) {
+			return null;
+		}
+
+		return (String) account.get("email");
+	}
+
+	@Override
+	public String getNickname() {
+		Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+		if (account == null) {
+			return null;
+		}
+
+		Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+		if (profile == null) {
+			return null;
+		}
+
+		return (String) profile.get("nickname");
+	}
+
+	@Override
+	public String getImageUrl() {
+		Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+		if (account == null) {
+			return null;
+		}
+
+		Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+		if (profile == null) {
+			return null;
+		}
+
+		return (String) profile.get("thumbnail_image_url");
+	}
+}

--- a/src/main/java/TripleS/VidiLang/oauth2/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/TripleS/VidiLang/oauth2/userInfo/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package TripleS.VidiLang.oauth2.userInfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+	protected Map<String, Object> attributes;
+
+	public OAuth2UserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public abstract String getId();
+
+	public abstract String getEmail();
+
+	public abstract String getNickname();
+
+	public abstract String getImageUrl();
+
+}


### PR DESCRIPTION
## 🌿 제목
- 소셜 로그인 및 자체 로그인 기능 구현

## 🌱 작업한 내용 / 변경된 사항
✅ 소셜 로그인 및 자체 로그인 구현
OAuth2(Kakao, Google) 기반 소셜 로그인 기능 추가
자체 로그인 기능 구현

✅ JWT 토큰 발급 및 인증
email, socialType을 기반으로 AccessToken 및 RefreshToken 생성
RefreshToken은 Redis에 저장

✅ SecurityConfig(SecurityFilterChain) 설정 추가
🔹 JWT 필터 적용
JwtFilter를 UsernamePasswordAuthenticationFilter 앞에 배치하여 인증 필터를 선행 실행
커스텀 로그인 필터 (CustomJsonUsernamePasswordAuthenticationFilter) 추가
JSON 기반 로그인 요청을 처리하는 필터 적용

🔹 OAuth2 로그인 성공 및 실패 핸들러 설정
OAuth2LoginSuccessHandler 및 OAuth2LoginFailureHandler 적용

🔹 CORS 설정 추가
모든 Origin 허용 (AllowedOriginPatterns("*"))
허용된 HTTP 메서드
GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS

🔹 기타 보안 설정
CSRF 비활성화
FormLogin 비활성화

## 👀 전달사항
- 로그인 부분만 구현했습니다! 로그아웃, 토큰 재발급 부분은 추후에 진행하겠습니다. 
- 현재 코드가 jwt filter 부분에서 예외발생이 안되는 문제가 있습니다. 수정 후 pr 올릴까 하다가 혹시라도 늦어지지 않을까 해서 미리 올려요! 
- 또 토큰 생성 시  email, socialType을 기반으로 생성하게 코드를 구현했는데 처음에는 소셜 로그인과 자체 로그인 사용자를 명확하게 구분하기 위해서 이렇게 코드를 구현했는데 생각해보니 굳이 나눌 필요가 있을지.. 괜히 코드만 길어지는 것 같아 리뷰 해주시면 리팩토링 하겠습니다. 

## ☘️ 반영 브랜치
feat#8 -> develop

## 🍀 관련 이슈
Resolved: #8

## 🌵 테스트
![image](https://github.com/user-attachments/assets/396cc3ef-f4b0-450f-a01b-8d937e8c500f)

